### PR TITLE
NFT marketplace V2

### DIFF
--- a/projects/nft-markets/contracts/ERC721NFTMarketV2.sol
+++ b/projects/nft-markets/contracts/ERC721NFTMarketV2.sol
@@ -1,0 +1,767 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+pragma abicoder v2;
+
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/security/ReentrancyGuard.sol";
+import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+import {ERC721Holder} from "@openzeppelin/contracts/token/ERC721/utils/ERC721Holder.sol";
+
+import {IWETH} from "./interfaces/IWETH.sol";
+
+import {ICollectionWhitelistChecker} from "./interfaces/ICollectionWhitelistChecker.sol";
+
+contract ERC721NFTMarketV2 is ERC721Holder, Ownable, ReentrancyGuard {
+    using EnumerableSet for EnumerableSet.AddressSet;
+    using EnumerableSet for EnumerableSet.UintSet;
+
+    using SafeERC20 for IERC20;
+
+    enum CollectionStatus {
+        Pending,
+        Open,
+        Close
+    }
+
+    address public immutable WBNB;
+    address public immutable Cake;
+
+    uint256 public constant TOTAL_MAX_FEE = 1000; // 10% of a sale
+
+    address public adminAddress;
+    address public treasuryAddress;
+
+    uint256 public minimumAskPrice; // in wei
+    uint256 public maximumAskPrice; // in wei
+    uint256 public minimumAskCakePrice;
+    uint256 public maximumAskCakePrice;
+
+    mapping(address => uint256) public pendingRevenue; // For creator/treasury to claim
+    mapping(address => uint256) public cakePendingRevenue; // For creator/treasury to claim
+
+    EnumerableSet.AddressSet private _collectionAddressSet;
+
+    mapping(address => mapping(uint256 => Ask)) private _askDetails; // Ask details (price + seller address) for a given collection and a tokenId
+    mapping(address => EnumerableSet.UintSet) private _askTokenIds; // Set of tokenIds for a collection
+    mapping(address => Collection) private _collections; // Details about the collections
+    mapping(address => mapping(address => EnumerableSet.UintSet)) private _tokenIdsOfSellerForCollection;
+
+    enum Currency {
+        BNB,
+        Cake
+    }
+
+    struct Ask {
+        address seller; // address of the seller
+        uint256 price; // price of the token
+        Currency currency;
+    }
+
+    struct Collection {
+        CollectionStatus status; // status of the collection
+        address creatorAddress; // address of the creator
+        address whitelistChecker; // whitelist checker (if not set --> 0x00)
+        uint256 tradingFee; // trading fee (100 = 1%, 500 = 5%, 5 = 0.05%)
+        uint256 creatorFee; // creator fee (100 = 1%, 500 = 5%, 5 = 0.05%)
+    }
+
+    // Ask order is cancelled
+    event AskCancel(address indexed collection, address indexed seller, uint256 indexed tokenId);
+
+    // Ask order is created
+    event AskNew(
+        address indexed collection,
+        address indexed seller,
+        uint256 indexed tokenId,
+        uint256 askPrice,
+        Currency currency
+    );
+
+    // Ask order is updated
+    event AskUpdate(
+        address indexed collection,
+        address indexed seller,
+        uint256 indexed tokenId,
+        uint256 askPrice,
+        Currency currency
+    );
+
+    // Collection is closed for trading and new listings
+    event CollectionClose(address indexed collection);
+
+    // New collection is added
+    event CollectionNew(
+        address indexed collection,
+        address indexed creator,
+        address indexed whitelistChecker,
+        uint256 tradingFee,
+        uint256 creatorFee
+    );
+
+    // Existing collection is updated
+    event CollectionUpdate(
+        address indexed collection,
+        address indexed creator,
+        address indexed whitelistChecker,
+        uint256 tradingFee,
+        uint256 creatorFee
+    );
+
+    // Admin and Treasury Addresses are updated
+    event NewAdminAndTreasuryAddresses(address indexed admin, address indexed treasury);
+
+    // Minimum/maximum ask prices are updated
+    event NewMinimumAndMaximumAskPrices(uint256 minimumAskPrice, uint256 maximumAskPrice);
+
+    // Recover NFT tokens sent by accident
+    event NonFungibleTokenRecovery(address indexed token, uint256 indexed tokenId);
+
+    // Pending revenue is claimed
+    event RevenueClaim(address indexed claimer, uint256 amount, uint256 cakeAmount);
+
+    // Recover ERC20 tokens sent by accident
+    event TokenRecovery(address indexed token, uint256 amount);
+
+    // Ask order is matched by a trade
+    event Trade(
+        address indexed collection,
+        uint256 indexed tokenId,
+        address indexed seller,
+        address buyer,
+        uint256 askPrice,
+        uint256 netPrice,
+        bool withBNB
+    );
+
+    // Modifier for the admin
+    modifier onlyAdmin() {
+        require(msg.sender == adminAddress, "Management: Not admin");
+        _;
+    }
+
+    /**
+     * @notice Constructor
+     * @param _adminAddress: address of the admin
+     * @param _treasuryAddress: address of the treasury
+     * @param _WBNBAddress: WBNB address
+     * @param _minimumAskPrice: minimum ask price
+     * @param _maximumAskPrice: maximum ask price
+     */
+    constructor(
+        address _adminAddress,
+        address _treasuryAddress,
+        address _WBNBAddress,
+        address _CakeAddress,
+        uint256 _minimumAskPrice,
+        uint256 _maximumAskPrice,
+        uint256 _minimumAskCakePrice,
+        uint256 _maximumAskCakePrice
+    ) {
+        require(_adminAddress != address(0), "Operations: Admin address cannot be zero");
+        require(_treasuryAddress != address(0), "Operations: Treasury address cannot be zero");
+        require(_WBNBAddress != address(0), "Operations: WBNB address cannot be zero");
+        require(_CakeAddress != address(0), "Operations: Cake address cannot be zero");
+        require(_minimumAskPrice > 0, "Operations: _minimumAskPrice must be > 0");
+        require(_minimumAskPrice < _maximumAskPrice, "Operations: _minimumAskPrice < _maximumAskPrice");
+        require(_minimumAskCakePrice < _maximumAskCakePrice, "Operations: _minimumAskCakePrice < _maximumAskCakePrice");
+
+        adminAddress = _adminAddress;
+        treasuryAddress = _treasuryAddress;
+
+        WBNB = _WBNBAddress;
+        Cake = _CakeAddress;
+
+        minimumAskPrice = _minimumAskPrice;
+        maximumAskPrice = _maximumAskPrice;
+        minimumAskCakePrice = _minimumAskCakePrice;
+        maximumAskCakePrice = _maximumAskCakePrice;
+    }
+
+    /**
+     * @notice Buy token with BNB by matching the price of an existing ask order
+     * @param _collection: contract address of the NFT
+     * @param _tokenId: tokenId of the NFT purchased
+     */
+    function buyTokenUsingBNB(address _collection, uint256 _tokenId) external payable nonReentrant {
+        // Wrap BNB
+        IWETH(WBNB).deposit{value: msg.value}();
+
+        _buyToken(_collection, _tokenId, msg.value, true, Currency.BNB);
+    }
+
+    /**
+     * @notice Buy token with WBNB by matching the price of an existing ask order
+     * @param _collection: contract address of the NFT
+     * @param _tokenId: tokenId of the NFT purchased
+     * @param _price: price (must be equal to the askPrice set by the seller)
+     */
+    function buyTokenUsingWBNB(
+        address _collection,
+        uint256 _tokenId,
+        uint256 _price
+    ) external nonReentrant {
+        IERC20(WBNB).safeTransferFrom(address(msg.sender), address(this), _price);
+
+        _buyToken(_collection, _tokenId, _price, false, Currency.BNB);
+    }
+
+    /**
+     * @notice Buy token with Cake by matching the price of an existing ask order
+     * @param _collection: contract address of the NFT
+     * @param _tokenId: tokenId of the NFT purchased
+     * @param _price: price (must be equal to the askPrice set by the seller)
+     */
+    function buyTokenUsingCake(
+        address _collection,
+        uint256 _tokenId,
+        uint256 _price
+    ) external nonReentrant {
+        IERC20(Cake).safeTransferFrom(address(msg.sender), address(this), _price);
+
+        _buyToken(_collection, _tokenId, _price, false, Currency.Cake);
+    }
+
+    /**
+     * @notice Cancel existing ask order
+     * @param _collection: contract address of the NFT
+     * @param _tokenId: tokenId of the NFT
+     */
+    function cancelAskOrder(address _collection, uint256 _tokenId) external nonReentrant {
+        // Verify the sender has listed it
+        require(_tokenIdsOfSellerForCollection[msg.sender][_collection].contains(_tokenId), "Order: Token not listed");
+
+        // Adjust the information
+        _tokenIdsOfSellerForCollection[msg.sender][_collection].remove(_tokenId);
+        delete _askDetails[_collection][_tokenId];
+        _askTokenIds[_collection].remove(_tokenId);
+
+        // Transfer the NFT back to the user
+        IERC721(_collection).transferFrom(address(this), address(msg.sender), _tokenId);
+
+        // Emit event
+        emit AskCancel(_collection, msg.sender, _tokenId);
+    }
+
+    /**
+     * @notice Claim pending revenue (treasury or creators)
+     */
+    function claimPendingRevenue() external nonReentrant {
+        uint256 revenueToClaim = pendingRevenue[msg.sender];
+        uint256 cakeToClaim = cakePendingRevenue[msg.sender];
+        require(revenueToClaim != 0 || cakeToClaim != 0, "Claim: Nothing to claim");
+        pendingRevenue[msg.sender] = 0;
+        cakePendingRevenue[msg.sender] = 0;
+
+        IERC20(WBNB).safeTransfer(address(msg.sender), revenueToClaim);
+        IERC20(Cake).safeTransfer(address(msg.sender), cakeToClaim);
+
+        emit RevenueClaim(msg.sender, revenueToClaim, cakeToClaim);
+    }
+
+    /**
+     * @notice Create ask order
+     * @param _collection: contract address of the NFT
+     * @param _tokenId: tokenId of the NFT
+     * @param _askPrice: price for listing (in wei)
+     */
+    function createAskOrder(
+        address _collection,
+        uint256 _tokenId,
+        uint256 _askPrice,
+        Currency _currency
+    ) external nonReentrant {
+        // Verify price is not too low/high
+        if (_currency == Currency.BNB) {
+            require(_askPrice >= minimumAskPrice && _askPrice <= maximumAskPrice, "Order: Price not within range");
+        } else {
+            require(
+                _askPrice >= minimumAskCakePrice && _askPrice <= maximumAskCakePrice,
+                "Order: Price not within range"
+            );
+        }
+
+        // Verify collection is accepted
+        require(_collections[_collection].status == CollectionStatus.Open, "Collection: Not for listing");
+
+        // Verify token has restriction
+        require(_canTokenBeListed(_collection, _tokenId), "Order: tokenId not eligible");
+
+        // Transfer NFT to this contract
+        IERC721(_collection).safeTransferFrom(address(msg.sender), address(this), _tokenId);
+
+        // Adjust the information
+        _tokenIdsOfSellerForCollection[msg.sender][_collection].add(_tokenId);
+        _askDetails[_collection][_tokenId] = Ask({seller: msg.sender, price: _askPrice, currency: _currency});
+
+        // Add tokenId to the askTokenIds set
+        _askTokenIds[_collection].add(_tokenId);
+
+        // Emit event
+        emit AskNew(_collection, msg.sender, _tokenId, _askPrice, _currency);
+    }
+
+    /**
+     * @notice Modify existing ask order
+     * @param _collection: contract address of the NFT
+     * @param _tokenId: tokenId of the NFT
+     * @param _newPrice: new price for listing (in wei)
+     */
+    function modifyAskOrder(
+        address _collection,
+        uint256 _tokenId,
+        uint256 _newPrice,
+        Currency _newCurrency
+    ) external nonReentrant {
+        // Verify new price is not too low/high
+        if (_newCurrency == Currency.BNB) {
+            require(_newPrice >= minimumAskPrice && _newPrice <= maximumAskPrice, "Order: Price not within range");
+        } else {
+            require(
+                _newPrice >= minimumAskCakePrice && _newPrice <= maximumAskCakePrice,
+                "Order: Price not within range"
+            );
+        }
+        // Verify collection is accepted
+        require(_collections[_collection].status == CollectionStatus.Open, "Collection: Not for listing");
+
+        // Verify the sender has listed it
+        require(_tokenIdsOfSellerForCollection[msg.sender][_collection].contains(_tokenId), "Order: Token not listed");
+
+        // Adjust the information
+        _askDetails[_collection][_tokenId].price = _newPrice;
+        _askDetails[_collection][_tokenId].currency = _newCurrency;
+
+        // Emit event
+        emit AskUpdate(_collection, msg.sender, _tokenId, _newPrice, _newCurrency);
+    }
+
+    /**
+     * @notice Add a new collection
+     * @param _collection: collection address
+     * @param _creator: creator address (must be 0x00 if none)
+     * @param _whitelistChecker: whitelist checker (for additional restrictions, must be 0x00 if none)
+     * @param _tradingFee: trading fee (100 = 1%, 500 = 5%, 5 = 0.05%)
+     * @param _creatorFee: creator fee (100 = 1%, 500 = 5%, 5 = 0.05%, 0 if creator is 0x00)
+     * @dev Callable by admin
+     */
+    function addCollection(
+        address _collection,
+        address _creator,
+        address _whitelistChecker,
+        uint256 _tradingFee,
+        uint256 _creatorFee
+    ) external onlyAdmin {
+        require(!_collectionAddressSet.contains(_collection), "Operations: Collection already listed");
+        require(IERC721(_collection).supportsInterface(0x80ac58cd), "Operations: Not ERC721");
+
+        require(
+            (_creatorFee == 0 && _creator == address(0)) || (_creatorFee != 0 && _creator != address(0)),
+            "Operations: Creator parameters incorrect"
+        );
+
+        require(_tradingFee + _creatorFee <= TOTAL_MAX_FEE, "Operations: Sum of fee must inferior to TOTAL_MAX_FEE");
+
+        _collectionAddressSet.add(_collection);
+
+        _collections[_collection] = Collection({
+            status: CollectionStatus.Open,
+            creatorAddress: _creator,
+            whitelistChecker: _whitelistChecker,
+            tradingFee: _tradingFee,
+            creatorFee: _creatorFee
+        });
+
+        emit CollectionNew(_collection, _creator, _whitelistChecker, _tradingFee, _creatorFee);
+    }
+
+    /**
+     * @notice Allows the admin to close collection for trading and new listing
+     * @param _collection: collection address
+     * @dev Callable by admin
+     */
+    function closeCollectionForTradingAndListing(address _collection) external onlyAdmin {
+        require(_collectionAddressSet.contains(_collection), "Operations: Collection not listed");
+
+        _collections[_collection].status = CollectionStatus.Close;
+        _collectionAddressSet.remove(_collection);
+
+        emit CollectionClose(_collection);
+    }
+
+    /**
+     * @notice Modify collection characteristics
+     * @param _collection: collection address
+     * @param _creator: creator address (must be 0x00 if none)
+     * @param _whitelistChecker: whitelist checker (for additional restrictions, must be 0x00 if none)
+     * @param _tradingFee: trading fee (100 = 1%, 500 = 5%, 5 = 0.05%)
+     * @param _creatorFee: creator fee (100 = 1%, 500 = 5%, 5 = 0.05%, 0 if creator is 0x00)
+     * @dev Callable by admin
+     */
+    function modifyCollection(
+        address _collection,
+        address _creator,
+        address _whitelistChecker,
+        uint256 _tradingFee,
+        uint256 _creatorFee
+    ) external onlyAdmin {
+        require(_collectionAddressSet.contains(_collection), "Operations: Collection not listed");
+
+        require(
+            (_creatorFee == 0 && _creator == address(0)) || (_creatorFee != 0 && _creator != address(0)),
+            "Operations: Creator parameters incorrect"
+        );
+
+        require(_tradingFee + _creatorFee <= TOTAL_MAX_FEE, "Operations: Sum of fee must inferior to TOTAL_MAX_FEE");
+
+        _collections[_collection] = Collection({
+            status: CollectionStatus.Open,
+            creatorAddress: _creator,
+            whitelistChecker: _whitelistChecker,
+            tradingFee: _tradingFee,
+            creatorFee: _creatorFee
+        });
+
+        emit CollectionUpdate(_collection, _creator, _whitelistChecker, _tradingFee, _creatorFee);
+    }
+
+    /**
+     * @notice Allows the admin to update minimum and maximum prices for a token (in wei)
+     * @param _minimumAskPrice: minimum ask price
+     * @param _maximumAskPrice: maximum ask price
+     * @dev Callable by admin
+     */
+    function updateMinimumAndMaximumPrices(uint256 _minimumAskPrice, uint256 _maximumAskPrice) external onlyAdmin {
+        require(_minimumAskPrice < _maximumAskPrice, "Operations: _minimumAskPrice < _maximumAskPrice");
+
+        minimumAskPrice = _minimumAskPrice;
+        maximumAskPrice = _maximumAskPrice;
+
+        emit NewMinimumAndMaximumAskPrices(_minimumAskPrice, _maximumAskPrice);
+    }
+
+    /**
+     * @notice Allows the owner to recover tokens sent to the contract by mistake
+     * @param _token: token address
+     * @dev Callable by owner
+     */
+    function recoverFungibleTokens(address _token) external onlyOwner {
+        require(_token != WBNB, "Operations: Cannot recover WBNB");
+        uint256 amountToRecover = IERC20(_token).balanceOf(address(this));
+        require(amountToRecover != 0, "Operations: No token to recover");
+
+        IERC20(_token).safeTransfer(address(msg.sender), amountToRecover);
+
+        emit TokenRecovery(_token, amountToRecover);
+    }
+
+    /**
+     * @notice Allows the owner to recover NFTs sent to the contract by mistake
+     * @param _token: NFT token address
+     * @param _tokenId: tokenId
+     * @dev Callable by owner
+     */
+    function recoverNonFungibleToken(address _token, uint256 _tokenId) external onlyOwner nonReentrant {
+        require(!_askTokenIds[_token].contains(_tokenId), "Operations: NFT not recoverable");
+        IERC721(_token).safeTransferFrom(address(this), address(msg.sender), _tokenId);
+
+        emit NonFungibleTokenRecovery(_token, _tokenId);
+    }
+
+    /**
+     * @notice Set admin address
+     * @dev Only callable by owner
+     * @param _adminAddress: address of the admin
+     * @param _treasuryAddress: address of the treasury
+     */
+    function setAdminAndTreasuryAddresses(address _adminAddress, address _treasuryAddress) external onlyOwner {
+        require(_adminAddress != address(0), "Operations: Admin address cannot be zero");
+        require(_treasuryAddress != address(0), "Operations: Treasury address cannot be zero");
+
+        adminAddress = _adminAddress;
+        treasuryAddress = _treasuryAddress;
+
+        emit NewAdminAndTreasuryAddresses(_adminAddress, _treasuryAddress);
+    }
+
+    /**
+     * @notice Check asks for an array of tokenIds in a collection
+     * @param collection: address of the collection
+     * @param tokenIds: array of tokenId
+     */
+    function viewAsksByCollectionAndTokenIds(address collection, uint256[] calldata tokenIds)
+        external
+        view
+        returns (bool[] memory statuses, Ask[] memory askInfo)
+    {
+        uint256 length = tokenIds.length;
+
+        statuses = new bool[](length);
+        askInfo = new Ask[](length);
+
+        for (uint256 i = 0; i < length; i++) {
+            if (_askTokenIds[collection].contains(tokenIds[i])) {
+                statuses[i] = true;
+            } else {
+                statuses[i] = false;
+            }
+
+            askInfo[i] = _askDetails[collection][tokenIds[i]];
+        }
+
+        return (statuses, askInfo);
+    }
+
+    /**
+     * @notice View ask orders for a given collection across all sellers
+     * @param collection: address of the collection
+     * @param cursor: cursor
+     * @param size: size of the response
+     */
+    function viewAsksByCollection(
+        address collection,
+        uint256 cursor,
+        uint256 size
+    )
+        external
+        view
+        returns (
+            uint256[] memory tokenIds,
+            Ask[] memory askInfo,
+            uint256
+        )
+    {
+        uint256 length = size;
+
+        if (length > _askTokenIds[collection].length() - cursor) {
+            length = _askTokenIds[collection].length() - cursor;
+        }
+
+        tokenIds = new uint256[](length);
+        askInfo = new Ask[](length);
+
+        for (uint256 i = 0; i < length; i++) {
+            tokenIds[i] = _askTokenIds[collection].at(cursor + i);
+            askInfo[i] = _askDetails[collection][tokenIds[i]];
+        }
+
+        return (tokenIds, askInfo, cursor + length);
+    }
+
+    /**
+     * @notice View ask orders for a given collection and a seller
+     * @param collection: address of the collection
+     * @param seller: address of the seller
+     * @param cursor: cursor
+     * @param size: size of the response
+     */
+    function viewAsksByCollectionAndSeller(
+        address collection,
+        address seller,
+        uint256 cursor,
+        uint256 size
+    )
+        external
+        view
+        returns (
+            uint256[] memory tokenIds,
+            Ask[] memory askInfo,
+            uint256
+        )
+    {
+        uint256 length = size;
+
+        if (length > _tokenIdsOfSellerForCollection[seller][collection].length() - cursor) {
+            length = _tokenIdsOfSellerForCollection[seller][collection].length() - cursor;
+        }
+
+        tokenIds = new uint256[](length);
+        askInfo = new Ask[](length);
+
+        for (uint256 i = 0; i < length; i++) {
+            tokenIds[i] = _tokenIdsOfSellerForCollection[seller][collection].at(cursor + i);
+            askInfo[i] = _askDetails[collection][tokenIds[i]];
+        }
+
+        return (tokenIds, askInfo, cursor + length);
+    }
+
+    /*
+     * @notice View addresses and details for all the collections available for trading
+     * @param cursor: cursor
+     * @param size: size of the response
+     */
+    function viewCollections(uint256 cursor, uint256 size)
+        external
+        view
+        returns (
+            address[] memory collectionAddresses,
+            Collection[] memory collectionDetails,
+            uint256
+        )
+    {
+        uint256 length = size;
+
+        if (length > _collectionAddressSet.length() - cursor) {
+            length = _collectionAddressSet.length() - cursor;
+        }
+
+        collectionAddresses = new address[](length);
+        collectionDetails = new Collection[](length);
+
+        for (uint256 i = 0; i < length; i++) {
+            collectionAddresses[i] = _collectionAddressSet.at(cursor + i);
+            collectionDetails[i] = _collections[collectionAddresses[i]];
+        }
+
+        return (collectionAddresses, collectionDetails, cursor + length);
+    }
+
+    /**
+     * @notice Calculate price and associated fees for a collection
+     * @param collection: address of the collection
+     * @param price: listed price
+     */
+    function calculatePriceAndFeesForCollection(address collection, uint256 price)
+        external
+        view
+        returns (
+            uint256 netPrice,
+            uint256 tradingFee,
+            uint256 creatorFee
+        )
+    {
+        if (_collections[collection].status != CollectionStatus.Open) {
+            return (0, 0, 0);
+        }
+
+        return (_calculatePriceAndFeesForCollection(collection, price));
+    }
+
+    /**
+     * @notice Checks if an array of tokenIds can be listed
+     * @param _collection: address of the collection
+     * @param _tokenIds: array of tokenIds
+     * @dev if collection is not for trading, it returns array of bool with false
+     */
+    function canTokensBeListed(address _collection, uint256[] calldata _tokenIds)
+        external
+        view
+        returns (bool[] memory listingStatuses)
+    {
+        listingStatuses = new bool[](_tokenIds.length);
+
+        if (_collections[_collection].status != CollectionStatus.Open) {
+            return listingStatuses;
+        }
+
+        for (uint256 i = 0; i < _tokenIds.length; i++) {
+            listingStatuses[i] = _canTokenBeListed(_collection, _tokenIds[i]);
+        }
+
+        return listingStatuses;
+    }
+
+    /**
+     * @notice Buy token by matching the price of an existing ask order
+     * @param _collection: contract address of the NFT
+     * @param _tokenId: tokenId of the NFT purchased
+     * @param _price: price (must match the askPrice from the seller)
+     * @param _withBNB: whether the token is bought with BNB (true) or WBNB (false)
+     */
+    function _buyToken(
+        address _collection,
+        uint256 _tokenId,
+        uint256 _price,
+        bool _withBNB,
+        Currency _currency
+    ) internal {
+        require(_collections[_collection].status == CollectionStatus.Open, "Collection: Not for trading");
+        require(_askTokenIds[_collection].contains(_tokenId), "Buy: Not for sale");
+
+        Ask memory askOrder = _askDetails[_collection][_tokenId];
+
+        // Front-running protection
+        require(askOrder.currency == _currency, "Ask: Wrong currency");
+        require(_price == askOrder.price, "Buy: Incorrect price");
+        require(msg.sender != askOrder.seller, "Buy: Buyer cannot be seller");
+
+        // Calculate the net price (collected by seller), trading fee (collected by treasury), creator fee (collected by creator)
+        (uint256 netPrice, uint256 tradingFee, uint256 creatorFee) = _calculatePriceAndFeesForCollection(
+            _collection,
+            _price
+        );
+
+        // Update storage information
+        _tokenIdsOfSellerForCollection[askOrder.seller][_collection].remove(_tokenId);
+        delete _askDetails[_collection][_tokenId];
+        _askTokenIds[_collection].remove(_tokenId);
+
+        // Transfer WBNB
+        if (_currency == Currency.BNB) {
+            IERC20(WBNB).safeTransfer(askOrder.seller, netPrice);
+        } else {
+            IERC20(Cake).safeTransfer(askOrder.seller, netPrice);
+        }
+
+        // Update pending revenues for treasury/creator (if any!)
+        if (creatorFee != 0) {
+            if (_currency == Currency.BNB) {
+                pendingRevenue[_collections[_collection].creatorAddress] += creatorFee;
+            } else {
+                cakePendingRevenue[_collections[_collection].creatorAddress] += creatorFee;
+            }
+        }
+
+        // Update trading fee if not equal to 0
+        if (tradingFee != 0) {
+            if (_currency == Currency.BNB) {
+                pendingRevenue[treasuryAddress] += tradingFee;
+            } else {
+                cakePendingRevenue[treasuryAddress] += tradingFee;
+            }
+        }
+
+        // Transfer NFT to buyer
+        IERC721(_collection).safeTransferFrom(address(this), address(msg.sender), _tokenId);
+
+        // Emit event
+        emit Trade(_collection, _tokenId, askOrder.seller, msg.sender, _price, netPrice, _withBNB);
+    }
+
+    /**
+     * @notice Calculate price and associated fees for a collection
+     * @param _collection: address of the collection
+     * @param _askPrice: listed price
+     */
+    function _calculatePriceAndFeesForCollection(address _collection, uint256 _askPrice)
+        internal
+        view
+        returns (
+            uint256 netPrice,
+            uint256 tradingFee,
+            uint256 creatorFee
+        )
+    {
+        tradingFee = (_askPrice * _collections[_collection].tradingFee) / 10000;
+        creatorFee = (_askPrice * _collections[_collection].creatorFee) / 10000;
+
+        netPrice = _askPrice - tradingFee - creatorFee;
+
+        return (netPrice, tradingFee, creatorFee);
+    }
+
+    /**
+     * @notice Checks if a token can be listed
+     * @param _collection: address of the collection
+     * @param _tokenId: tokenId
+     */
+    function _canTokenBeListed(address _collection, uint256 _tokenId) internal view returns (bool) {
+        address whitelistCheckerAddress = _collections[_collection].whitelistChecker;
+        return
+            (whitelistCheckerAddress == address(0)) ||
+            ICollectionWhitelistChecker(whitelistCheckerAddress).canList(_tokenId);
+    }
+}

--- a/projects/nft-markets/data/abi/contracts/ERC721NFTMarketV2.sol/ERC721NFTMarketV2.json
+++ b/projects/nft-markets/data/abi/contracts/ERC721NFTMarketV2.sol/ERC721NFTMarketV2.json
@@ -1,0 +1,1198 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_adminAddress",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_treasuryAddress",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_WBNBAddress",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_CakeAddress",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_minimumAskPrice",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_maximumAskPrice",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_minimumAskCakePrice",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_maximumAskCakePrice",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "collection",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "seller",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "AskCancel",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "collection",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "seller",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "askPrice",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "enum ERC721NFTMarketV2.Currency",
+        "name": "currency",
+        "type": "uint8"
+      }
+    ],
+    "name": "AskNew",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "collection",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "seller",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "askPrice",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "enum ERC721NFTMarketV2.Currency",
+        "name": "currency",
+        "type": "uint8"
+      }
+    ],
+    "name": "AskUpdate",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "collection",
+        "type": "address"
+      }
+    ],
+    "name": "CollectionClose",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "collection",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "creator",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "whitelistChecker",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "tradingFee",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "creatorFee",
+        "type": "uint256"
+      }
+    ],
+    "name": "CollectionNew",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "collection",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "creator",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "whitelistChecker",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "tradingFee",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "creatorFee",
+        "type": "uint256"
+      }
+    ],
+    "name": "CollectionUpdate",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "admin",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "treasury",
+        "type": "address"
+      }
+    ],
+    "name": "NewAdminAndTreasuryAddresses",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "minimumAskPrice",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "maximumAskPrice",
+        "type": "uint256"
+      }
+    ],
+    "name": "NewMinimumAndMaximumAskPrices",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "NonFungibleTokenRecovery",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "claimer",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "cakeAmount",
+        "type": "uint256"
+      }
+    ],
+    "name": "RevenueClaim",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "TokenRecovery",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "collection",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "seller",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "buyer",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "askPrice",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "netPrice",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "withBNB",
+        "type": "bool"
+      }
+    ],
+    "name": "Trade",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "Cake",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "TOTAL_MAX_FEE",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "WBNB",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_collection",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_creator",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_whitelistChecker",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_tradingFee",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_creatorFee",
+        "type": "uint256"
+      }
+    ],
+    "name": "addCollection",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "adminAddress",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_collection",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "buyTokenUsingBNB",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_collection",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_tokenId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_price",
+        "type": "uint256"
+      }
+    ],
+    "name": "buyTokenUsingCake",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_collection",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_tokenId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_price",
+        "type": "uint256"
+      }
+    ],
+    "name": "buyTokenUsingWBNB",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "cakePendingRevenue",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "collection",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "price",
+        "type": "uint256"
+      }
+    ],
+    "name": "calculatePriceAndFeesForCollection",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "netPrice",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "tradingFee",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "creatorFee",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_collection",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "_tokenIds",
+        "type": "uint256[]"
+      }
+    ],
+    "name": "canTokensBeListed",
+    "outputs": [
+      {
+        "internalType": "bool[]",
+        "name": "listingStatuses",
+        "type": "bool[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_collection",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "cancelAskOrder",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "claimPendingRevenue",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_collection",
+        "type": "address"
+      }
+    ],
+    "name": "closeCollectionForTradingAndListing",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_collection",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_tokenId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_askPrice",
+        "type": "uint256"
+      },
+      {
+        "internalType": "enum ERC721NFTMarketV2.Currency",
+        "name": "_currency",
+        "type": "uint8"
+      }
+    ],
+    "name": "createAskOrder",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "maximumAskCakePrice",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "maximumAskPrice",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "minimumAskCakePrice",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "minimumAskPrice",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_collection",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_tokenId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_newPrice",
+        "type": "uint256"
+      },
+      {
+        "internalType": "enum ERC721NFTMarketV2.Currency",
+        "name": "_newCurrency",
+        "type": "uint8"
+      }
+    ],
+    "name": "modifyAskOrder",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_collection",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_creator",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_whitelistChecker",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_tradingFee",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_creatorFee",
+        "type": "uint256"
+      }
+    ],
+    "name": "modifyCollection",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
+      }
+    ],
+    "name": "onERC721Received",
+    "outputs": [
+      {
+        "internalType": "bytes4",
+        "name": "",
+        "type": "bytes4"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "pendingRevenue",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_token",
+        "type": "address"
+      }
+    ],
+    "name": "recoverFungibleTokens",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_token",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "recoverNonFungibleToken",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "renounceOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_adminAddress",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_treasuryAddress",
+        "type": "address"
+      }
+    ],
+    "name": "setAdminAndTreasuryAddresses",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "treasuryAddress",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_minimumAskPrice",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_maximumAskPrice",
+        "type": "uint256"
+      }
+    ],
+    "name": "updateMinimumAndMaximumPrices",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "collection",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "cursor",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "size",
+        "type": "uint256"
+      }
+    ],
+    "name": "viewAsksByCollection",
+    "outputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "tokenIds",
+        "type": "uint256[]"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "seller",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "price",
+            "type": "uint256"
+          },
+          {
+            "internalType": "enum ERC721NFTMarketV2.Currency",
+            "name": "currency",
+            "type": "uint8"
+          }
+        ],
+        "internalType": "struct ERC721NFTMarketV2.Ask[]",
+        "name": "askInfo",
+        "type": "tuple[]"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "collection",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "seller",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "cursor",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "size",
+        "type": "uint256"
+      }
+    ],
+    "name": "viewAsksByCollectionAndSeller",
+    "outputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "tokenIds",
+        "type": "uint256[]"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "seller",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "price",
+            "type": "uint256"
+          },
+          {
+            "internalType": "enum ERC721NFTMarketV2.Currency",
+            "name": "currency",
+            "type": "uint8"
+          }
+        ],
+        "internalType": "struct ERC721NFTMarketV2.Ask[]",
+        "name": "askInfo",
+        "type": "tuple[]"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "collection",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "tokenIds",
+        "type": "uint256[]"
+      }
+    ],
+    "name": "viewAsksByCollectionAndTokenIds",
+    "outputs": [
+      {
+        "internalType": "bool[]",
+        "name": "statuses",
+        "type": "bool[]"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "seller",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "price",
+            "type": "uint256"
+          },
+          {
+            "internalType": "enum ERC721NFTMarketV2.Currency",
+            "name": "currency",
+            "type": "uint8"
+          }
+        ],
+        "internalType": "struct ERC721NFTMarketV2.Ask[]",
+        "name": "askInfo",
+        "type": "tuple[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "cursor",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "size",
+        "type": "uint256"
+      }
+    ],
+    "name": "viewCollections",
+    "outputs": [
+      {
+        "internalType": "address[]",
+        "name": "collectionAddresses",
+        "type": "address[]"
+      },
+      {
+        "components": [
+          {
+            "internalType": "enum ERC721NFTMarketV2.CollectionStatus",
+            "name": "status",
+            "type": "uint8"
+          },
+          {
+            "internalType": "address",
+            "name": "creatorAddress",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "whitelistChecker",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "tradingFee",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "creatorFee",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct ERC721NFTMarketV2.Collection[]",
+        "name": "collectionDetails",
+        "type": "tuple[]"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/projects/nft-markets/test/ERC721NFTMarketV2.ts
+++ b/projects/nft-markets/test/ERC721NFTMarketV2.ts
@@ -1,0 +1,1554 @@
+import { parseEther } from "ethers/lib/utils";
+import { artifacts, contract } from "hardhat";
+import { assert } from "chai";
+import { BN, constants, expectEvent, expectRevert } from "@openzeppelin/test-helpers";
+
+const ERC721NFTMarketV2 = artifacts.require("./ERC721NFTMarketV2.sol");
+const PancakeBunniesWhitelistChecker = artifacts.require("./PancakeBunniesWhitelistChecker.sol");
+
+const MockERC20 = artifacts.require("./test/MockERC20.sol");
+const MockNFT = artifacts.require("./test/MockNFT.sol");
+const WBNB = artifacts.require("./test/WBNB.sol");
+const PancakeBunnies = artifacts.require(".test/PancakeBunnies.sol");
+
+contract(
+  "ERC721 NFT Market V2",
+  ([owner, admin, treasury, buyer1, buyer2, buyer3, seller1, seller2, seller3, creator1]) => {
+    // VARIABLES
+    let minimumAskPrice = parseEther("0.001");
+    let maximumAskPrice = parseEther("100");
+    let minimumAskCakePrice = 50;
+    let maximumAskCakePrice = 50000;
+
+    // Contracts
+    let collectibleMarket,
+      mockERC20,
+      mockNFT1,
+      mockNFT2,
+      mockNFT3,
+      mockNFT4,
+      mockNFT5,
+      mockNFT6,
+      pancakeBunnies,
+      pancakeBunniesChecker,
+      wrappedBNB,
+      cake;
+
+    before(async () => {
+      // Deploy WBNB
+      wrappedBNB = await WBNB.new({ from: owner });
+
+      // Deploy Cake
+      cake = await MockERC20.new("Mock CAKE", "CAKE", 1000000, { from: owner });
+
+      await cake.mintTokens(20000, { from: buyer1 });
+
+      // Deploy CollectibleMarketV1
+      collectibleMarket = await ERC721NFTMarketV2.new(
+        admin,
+        treasury,
+        wrappedBNB.address,
+        cake.address,
+        minimumAskPrice,
+        maximumAskPrice,
+        minimumAskCakePrice,
+        maximumAskCakePrice,
+        { from: owner }
+      );
+
+      // Deploy PancakeBunnies (modified implementation in Solidity 0.8)
+      pancakeBunnies = await PancakeBunnies.new({ from: owner });
+
+      // Deploy pancakeBunniesChecker
+      pancakeBunniesChecker = await PancakeBunniesWhitelistChecker.new(pancakeBunnies.address, { from: owner });
+
+      // Deploy MockNFT 1
+      mockNFT1 = await MockNFT.new("Mock NFT 1", "MN1", { from: owner });
+
+      // Deploy MockNFT 2
+      mockNFT2 = await MockNFT.new("Mock NFT 2", "MN2", { from: owner });
+
+      // Deploy MockNFT 3
+      mockNFT3 = await MockNFT.new("Mock NFT 3", "MN3", { from: owner });
+
+      // Deploy MockNFT 4
+      mockNFT4 = await MockNFT.new("Mock NFT 4", "MN4", { from: owner });
+
+      // Deploy MockNFT 5
+      mockNFT5 = await MockNFT.new("Mock NFT 5", "MN5", { from: owner });
+
+      // Deploy MockNFT 5
+      mockNFT6 = await MockNFT.new("Mock NFT 6", "MN6", { from: owner });
+
+      // Deploy MockERC20
+      mockERC20 = await MockERC20.new("Mock ERC20", "ERC", parseEther("1000"), { from: owner });
+
+      // Mint 3 NFTs and approve
+      let i = 0;
+
+      for (let user of [seller1, seller2, seller3]) {
+        i++;
+        await mockNFT1.setApprovalForAll(collectibleMarket.address, true, { from: user });
+        await mockNFT2.setApprovalForAll(collectibleMarket.address, true, { from: user });
+        await mockNFT3.setApprovalForAll(collectibleMarket.address, true, { from: user });
+        await mockNFT5.setApprovalForAll(collectibleMarket.address, true, { from: user });
+        await mockNFT6.setApprovalForAll(collectibleMarket.address, true, { from: user });
+
+        await mockNFT1.mint("ipfs://token" + i + " .json", { from: user });
+        await mockNFT1.mint("ipfs://token" + i + " .json", { from: user });
+        await mockNFT2.mint("ipfs://token" + i + " .json", { from: user });
+        await mockNFT2.mint("ipfs://token" + i + " .json", { from: user });
+        await mockNFT3.mint("ipfs://token" + i + " .json", { from: user });
+        await mockNFT3.mint("ipfs://token" + i + " .json", { from: user });
+        await mockNFT5.mint("ipfs://token" + i + " .json", { from: user });
+        await mockNFT5.mint("ipfs://token" + i + " .json", { from: user });
+        await mockNFT6.mint("ipfs://token" + i + " .json", { from: user });
+        await mockNFT6.mint("ipfs://token" + i + " .json", { from: user });
+      }
+
+      for (let user of [buyer1, buyer2, buyer3, seller1, seller2, seller3]) {
+        await wrappedBNB.deposit({ value: parseEther("10").toString(), from: user });
+        await wrappedBNB.approve(collectibleMarket.address, constants.MAX_UINT256, { from: user });
+      }
+    });
+
+    describe("COLLECTIBLE MARKET #1 - NORMAL BEHAVIOR", async () => {
+      it("Admin adds a new collection (Mock NFT #1)", async () => {
+        const result = await collectibleMarket.addCollection(
+          mockNFT1.address,
+          constants.ZERO_ADDRESS,
+          constants.ZERO_ADDRESS,
+          "100", // 1%
+          "0",
+          { from: admin }
+        );
+
+        expectEvent(result, "CollectionNew", {
+          collection: mockNFT1.address,
+          creator: constants.ZERO_ADDRESS,
+          whitelistChecker: constants.ZERO_ADDRESS,
+          tradingFee: "100",
+          creatorFee: "0",
+        });
+
+        const collections = await collectibleMarket.viewCollections("0", "10");
+        assert.equal(collections[0][0], mockNFT1.address);
+        assert.equal(collections[1][0][0], "1"); // status
+        assert.equal(collections[1][0][1], constants.ZERO_ADDRESS); //
+        assert.equal(collections[1][0][2], constants.ZERO_ADDRESS);
+        assert.equal(String(collections[1][0][3]), "100");
+        assert.equal(String(collections[1][0][4]), "0");
+        assert.equal(String(collections[2]), "1"); // 1 collection
+
+        const tokensForSale = await collectibleMarket.viewAsksByCollection(mockNFT1.address, "0", "500");
+        assert.isEmpty(tokensForSale[0]); // Empty array
+        assert.isEmpty(tokensForSale[1]); // Empty array
+        assert.equal(String(tokensForSale[2]), "0"); // 0 token listed in the collection
+
+        const tokensForSaleForSeller = await collectibleMarket.viewAsksByCollectionAndSeller(
+          mockNFT1.address,
+          seller1,
+          "0",
+          "500"
+        );
+
+        assert.isEmpty(tokensForSaleForSeller[0]); // Empty array
+        assert.isEmpty(tokensForSaleForSeller[1]); // Empty array
+        assert.equal(String(tokensForSaleForSeller[2]), "0"); // number of tokens listed by seller1
+      });
+
+      it("Tokens can/cannot be listed for NFT1/NFT2", async () => {
+        let result = await collectibleMarket.canTokensBeListed(mockNFT1.address, ["0", "1", "2", "3", "4", "5"]);
+        let boolArray = Array.from({ length: 6 }, (i) => (i = true));
+
+        assert.sameOrderedMembers(result, boolArray);
+
+        result = await collectibleMarket.canTokensBeListed(mockNFT2.address, ["0", "1", "2", "3", "4", "5"]);
+        boolArray = Array.from({ length: 6 }, (i) => (i = false));
+
+        assert.sameOrderedMembers(result, boolArray);
+      });
+
+      it("Seller1 lists a NFT", async () => {
+        const result = await collectibleMarket.createAskOrder(mockNFT1.address, "0", parseEther("1"), 0, {
+          from: seller1,
+        });
+
+        expectEvent(result, "AskNew", {
+          collection: mockNFT1.address,
+          seller: seller1,
+          tokenId: "0",
+          askPrice: parseEther("1").toString(),
+          currency: "0",
+        });
+
+        expectEvent.inTransaction(result.receipt.transactionHash, mockNFT1, "Transfer", {
+          from: seller1,
+          to: collectibleMarket.address,
+          tokenId: "0",
+        });
+
+        const tokensForSale = await collectibleMarket.viewAsksByCollection(mockNFT1.address, "0", "500");
+        assert.equal(tokensForSale[0][0], "0"); // TokenId = 0
+        assert.equal(tokensForSale[1][0][0], seller1); // Address = seller1
+        assert.equal(String(tokensForSale[1][0][1]), parseEther("1").toString()); // Price = 1 BNB
+        assert.equal(String(tokensForSale[2]), "1"); // 1 token listed in the collection
+      });
+
+      it("Seller2 lists a NFT and modifies the order price", async () => {
+        let result = await collectibleMarket.createAskOrder(mockNFT1.address, "2", parseEther("1.2"), 0, {
+          from: seller2,
+        });
+
+        expectEvent(result, "AskNew", {
+          collection: mockNFT1.address,
+          seller: seller2,
+          tokenId: "2",
+          askPrice: parseEther("1.2").toString(),
+          currency: "0",
+        });
+
+        expectEvent.inTransaction(result.receipt.transactionHash, mockNFT1, "Transfer", {
+          from: seller2,
+          to: collectibleMarket.address,
+          tokenId: "2",
+        });
+
+        let tokensForSale = await collectibleMarket.viewAsksByCollection(mockNFT1.address, "0", "500");
+        assert.equal(tokensForSale[0][1], "2"); // TokenId = 2
+        assert.equal(tokensForSale[1][1][0], seller2); // Address = seller2
+        assert.equal(String(tokensForSale[1][1][1]), parseEther("1.2").toString()); // Price = 1.2 BNB
+        assert.equal(String(tokensForSale[2]), "2"); // 2 tokens listed in the collection
+
+        result = await collectibleMarket.modifyAskOrder(mockNFT1.address, "2", parseEther("2"), 0, {
+          from: seller2,
+        });
+
+        expectEvent(result, "AskUpdate", {
+          collection: mockNFT1.address,
+          seller: seller2,
+          tokenId: "2",
+          askPrice: parseEther("2").toString(),
+          currency: "0",
+        });
+
+        tokensForSale = await collectibleMarket.viewAsksByCollection(mockNFT1.address, "0", "500");
+        assert.equal(String(tokensForSale[1][1][1]), parseEther("2").toString()); // Price updated to 2 BNB
+      });
+
+      it("Seller2 cancels her order", async () => {
+        let result = await collectibleMarket.cancelAskOrder(mockNFT1.address, "2", {
+          from: seller2,
+        });
+
+        expectEvent(result, "AskCancel", {
+          collection: mockNFT1.address,
+          seller: seller2,
+          tokenId: "2",
+        });
+
+        expectEvent.inTransaction(result.receipt.transactionHash, mockNFT1, "Transfer", {
+          from: collectibleMarket.address,
+          to: seller2,
+          tokenId: "2",
+        });
+
+        let tokensForSale = await collectibleMarket.viewAsksByCollection(mockNFT1.address, "0", "500");
+        assert.isUndefined(tokensForSale[0][1]); // Array length is 1 so 2nd element is undefined
+        assert.isUndefined(tokensForSale[1][1]); // Array length is 1 so 2nd element is undefined
+        assert.equal(String(tokensForSale[2]), "1"); // 1 token listed in the collection
+      });
+
+      it("Buyer1 matches order from seller1 with BNB", async () => {
+        const marketPrice = parseEther("1").toString();
+
+        const estimations = await collectibleMarket.calculatePriceAndFeesForCollection(mockNFT1.address, marketPrice);
+        const expectedNetPrice = estimations[0];
+        const expectedTradingFee = estimations[1];
+        const expectedCreatorFee = estimations[2];
+
+        assert.equal(expectedNetPrice.toString(), parseEther("0.99").toString());
+        assert.equal(expectedTradingFee.toString(), parseEther("0.01").toString());
+        assert.equal(expectedCreatorFee.toString(), parseEther("0").toString());
+
+        const result = await collectibleMarket.buyTokenUsingBNB(mockNFT1.address, "0", {
+          value: marketPrice,
+          from: buyer1,
+        });
+
+        expectEvent(result, "Trade", {
+          collection: mockNFT1.address,
+          tokenId: "0",
+          seller: seller1,
+          buyer: buyer1,
+          askPrice: marketPrice,
+          netPrice: expectedNetPrice, // 1%
+          withBNB: true,
+        });
+
+        expectEvent.inTransaction(result.receipt.transactionHash, wrappedBNB, "Transfer", {
+          src: collectibleMarket.address,
+          dst: seller1,
+          wad: expectedNetPrice,
+        });
+
+        assert.equal(String(await collectibleMarket.pendingRevenue(treasury)), expectedTradingFee);
+
+        let tokensForSale = await collectibleMarket.viewAsksByCollection(mockNFT1.address, "0", "500");
+        assert.isUndefined(tokensForSale[0][0]); // Array length is 0 so 1st element is undefined
+        assert.isUndefined(tokensForSale[1][0]); // Array length is 1 so 1st element is undefined
+        assert.equal(String(tokensForSale[2]), "0"); // 1 token listed in the collection
+      });
+
+      it("Seller1 lists a second NFT that is bought by buyer1 with WBNB", async () => {
+        let result = await collectibleMarket.createAskOrder(mockNFT1.address, "1", parseEther("1.1"), 0, {
+          from: seller1,
+        });
+
+        expectEvent(result, "AskNew", {
+          collection: mockNFT1.address,
+          seller: seller1,
+          tokenId: "1",
+          askPrice: parseEther("1.1").toString(),
+          currency: "0",
+        });
+
+        expectEvent.inTransaction(result.receipt.transactionHash, mockNFT1, "Transfer", {
+          from: seller1,
+          to: collectibleMarket.address,
+          tokenId: "1",
+        });
+
+        result = await collectibleMarket.buyTokenUsingWBNB(mockNFT1.address, "1", parseEther("1.1").toString(), {
+          from: buyer1,
+        });
+
+        expectEvent(result, "Trade", {
+          collection: mockNFT1.address,
+          tokenId: "1",
+          seller: seller1,
+          buyer: buyer1,
+          askPrice: parseEther("1.1").toString(),
+          netPrice: parseEther("1.089").toString(), // 1%
+          withBNB: false,
+        });
+
+        expectEvent.inTransaction(result.receipt.transactionHash, wrappedBNB, "Transfer", {
+          src: collectibleMarket.address,
+          dst: seller1,
+          wad: parseEther("1.089").toString(),
+        });
+
+        assert.equal(String(await collectibleMarket.pendingRevenue(treasury)), parseEther("0.021").toString());
+      });
+
+      it("Seller1 cannot cancel order for a token previously sold by herself", async () => {
+        // Buyer1 approves contract to use all tokenIds
+        await mockNFT1.setApprovalForAll(collectibleMarket.address, true, { from: buyer1 });
+
+        // Buyer1 creates an order
+        await collectibleMarket.createAskOrder(mockNFT1.address, "1", parseEther("1.1"), 0, {
+          from: buyer1,
+        });
+
+        // Seller1 tries to cancel ask order
+        await expectRevert(
+          collectibleMarket.cancelAskOrder(mockNFT1.address, "1", {
+            from: seller1,
+          }),
+          "Order: Token not listed"
+        );
+
+        // Seller1 tries to modify ask order
+        await expectRevert(
+          collectibleMarket.modifyAskOrder(mockNFT1.address, "1", parseEther("1"), 0, {
+            from: seller1,
+          }),
+          "Order: Token not listed"
+        );
+
+        // Buyer1 cancels order
+        await collectibleMarket.cancelAskOrder(mockNFT1.address, "1", {
+          from: buyer1,
+        });
+      });
+
+      it("Treasury claims its pending revenue", async () => {
+        const result = await collectibleMarket.claimPendingRevenue({ from: treasury });
+
+        expectEvent.inTransaction(result.receipt.transactionHash, wrappedBNB, "Transfer", {
+          src: collectibleMarket.address,
+          dst: treasury,
+          wad: parseEther("0.021").toString(),
+        });
+
+        assert.equal(String(await collectibleMarket.pendingRevenue(treasury)), parseEther("0").toString());
+        assert.equal(String(await wrappedBNB.balanceOf(treasury)), parseEther("0.021").toString());
+
+        await expectRevert(collectibleMarket.claimPendingRevenue({ from: treasury }), "Claim: Nothing to claim");
+      });
+
+      it("Seller 3 adds 2 offers", async () => {
+        let result = await collectibleMarket.createAskOrder(mockNFT1.address, "4", parseEther("1.4"), 0, {
+          from: seller3,
+        });
+
+        expectEvent(result, "AskNew", {
+          collection: mockNFT1.address,
+          seller: seller3,
+          tokenId: "4",
+          askPrice: parseEther("1.4").toString(),
+          currency: "0",
+        });
+
+        result = await collectibleMarket.createAskOrder(mockNFT1.address, "5", parseEther("1.5"), 0, {
+          from: seller3,
+        });
+
+        expectEvent(result, "AskNew", {
+          collection: mockNFT1.address,
+          seller: seller3,
+          tokenId: "5",
+          askPrice: parseEther("1.5").toString(),
+          currency: "0",
+        });
+
+        const collections = await collectibleMarket.viewAsksByCollectionAndSeller(
+          mockNFT1.address,
+          seller3,
+          "0",
+          "500"
+        );
+
+        assert.equal(String(collections[0][0]), "4"); // tokenId
+        assert.equal(String(collections[0][1]), "5"); // tokenId
+
+        assert.equal(collections[1][0][0], seller3);
+        assert.equal(String(collections[1][0][1]), parseEther("1.4").toString());
+
+        assert.equal(collections[1][1][0], seller3);
+        assert.equal(String(collections[1][1][1]), parseEther("1.5").toString());
+        assert.equal(String(collections[2]), "2"); // number of tokens listed
+      });
+
+      it("Admin modifies the collection to remove all fees", async () => {
+        const result = await collectibleMarket.modifyCollection(
+          mockNFT1.address,
+          constants.ZERO_ADDRESS,
+          constants.ZERO_ADDRESS,
+          "0",
+          "0",
+          { from: admin }
+        );
+
+        expectEvent(result, "CollectionUpdate", {
+          collection: mockNFT1.address,
+          creator: constants.ZERO_ADDRESS,
+          whitelistChecker: constants.ZERO_ADDRESS,
+          tradingFee: "0",
+          creatorFee: "0",
+        });
+      });
+
+      it("Admin changes minimum/max prices to 10/11 BNB, seller3 cannot change price below", async () => {
+        const newMinPrice = parseEther("10");
+        const newMaxPrice = parseEther("11");
+
+        let result = await collectibleMarket.updateMinimumAndMaximumPrices(newMinPrice, newMaxPrice, { from: admin });
+
+        expectEvent(result, "NewMinimumAndMaximumAskPrices", {
+          minimumAskPrice: newMinPrice.toString(),
+          maximumAskPrice: newMaxPrice.toString(),
+        });
+
+        await expectRevert(
+          collectibleMarket.modifyAskOrder(mockNFT1.address, "5", parseEther("9.999999"), 0, {
+            from: seller2,
+          }),
+          "Order: Price not within range"
+        );
+
+        await expectRevert(
+          collectibleMarket.modifyAskOrder(mockNFT1.address, "5", parseEther("11.0000000000000001"), 0, {
+            from: seller2,
+          }),
+          "Order: Price not within range"
+        );
+
+        await expectRevert(
+          collectibleMarket.createAskOrder(mockNFT1.address, "4", parseEther("9.999999"), 0, {
+            from: seller2,
+          }),
+          "Order: Price not within range"
+        );
+
+        await expectRevert(
+          collectibleMarket.createAskOrder(mockNFT1.address, "4", parseEther("11.0000000000000001"), 0, {
+            from: seller2,
+          }),
+          "Order: Price not within range"
+        );
+
+        result = await collectibleMarket.updateMinimumAndMaximumPrices(minimumAskPrice, maximumAskPrice, {
+          from: admin,
+        });
+
+        expectEvent(result, "NewMinimumAndMaximumAskPrices", {
+          minimumAskPrice: minimumAskPrice.toString(),
+          maximumAskPrice: maximumAskPrice.toString(),
+        });
+      });
+
+      it("Buyer1 matches order, no fee is taken", async () => {
+        const marketPrice = parseEther("1.5").toString();
+
+        const estimations = await collectibleMarket.calculatePriceAndFeesForCollection(mockNFT1.address, marketPrice);
+        const expectedNetPrice = estimations[0];
+        const expectedTradingFee = estimations[1];
+        const expectedCreatorFee = estimations[2];
+
+        assert.equal(expectedNetPrice.toString(), parseEther("1.5").toString());
+        assert.equal(marketPrice, expectedNetPrice.toString());
+        assert.equal(expectedTradingFee.toString(), parseEther("0.00").toString());
+        assert.equal(expectedCreatorFee.toString(), parseEther("0").toString());
+
+        const result = await collectibleMarket.buyTokenUsingBNB(mockNFT1.address, "5", {
+          value: marketPrice,
+          from: buyer1,
+        });
+
+        expectEvent(result, "Trade", {
+          collection: mockNFT1.address,
+          tokenId: "5",
+          seller: seller3,
+          buyer: buyer1,
+          askPrice: marketPrice,
+          netPrice: expectedNetPrice,
+          withBNB: true,
+        });
+
+        expectEvent.inTransaction(result.receipt.transactionHash, wrappedBNB, "Transfer", {
+          src: collectibleMarket.address,
+          dst: seller3,
+          wad: expectedNetPrice,
+        });
+
+        assert.equal(String(await collectibleMarket.pendingRevenue(treasury)), "0");
+      });
+
+      it("Admin adds a second collection with fees for both creator/treasury", async () => {
+        const result = await collectibleMarket.addCollection(
+          mockNFT2.address,
+          creator1,
+          constants.ZERO_ADDRESS,
+          "45", // 0.45%
+          "5", // 0.05%
+          { from: admin }
+        );
+
+        expectEvent(result, "CollectionNew", {
+          collection: mockNFT2.address,
+          creator: creator1,
+          whitelistChecker: constants.ZERO_ADDRESS,
+          tradingFee: "45",
+          creatorFee: "5",
+        });
+
+        const collections = await collectibleMarket.viewCollections("0", "10");
+        assert.equal(String(collections[2]), "2"); // 2 collections are tradable
+      });
+
+      it("Seller 2 adds 2 offers for second collection", async () => {
+        let result = await collectibleMarket.createAskOrder(mockNFT2.address, "2", parseEther("1.2"), 0, {
+          from: seller2,
+        });
+
+        expectEvent(result, "AskNew", {
+          collection: mockNFT2.address,
+          seller: seller2,
+          tokenId: "2",
+          askPrice: parseEther("1.2").toString(),
+          currency: "0",
+        });
+
+        result = await collectibleMarket.createAskOrder(mockNFT2.address, "3", parseEther("1.3"), 0, {
+          from: seller2,
+        });
+
+        expectEvent(result, "AskNew", {
+          collection: mockNFT2.address,
+          seller: seller2,
+          tokenId: "3",
+          askPrice: parseEther("1.3").toString(),
+          currency: "0",
+        });
+
+        const collections = await collectibleMarket.viewAsksByCollectionAndSeller(
+          mockNFT2.address,
+          seller2,
+          "0",
+          "500"
+        );
+
+        assert.equal(String(collections[0][0]), "2"); // tokenId
+        assert.equal(String(collections[0][1]), "3"); // tokenId
+
+        assert.equal(collections[1][0][0], seller2);
+        assert.equal(String(collections[1][0][1]), parseEther("1.2").toString());
+
+        assert.equal(collections[1][1][0], seller2);
+        assert.equal(String(collections[1][1][1]), parseEther("1.3").toString());
+        assert.equal(String(collections[2]), "2"); // number of tokens listed
+      });
+
+      it("Buyer2 buys one of the 2 collectibles listed for the second collection", async () => {
+        const marketPrice = parseEther("1.2").toString();
+
+        const estimations = await collectibleMarket.calculatePriceAndFeesForCollection(mockNFT2.address, marketPrice);
+        const expectedNetPrice = estimations[0];
+        const expectedTradingFee = estimations[1]; // 0.45%
+        const expectedCreatorFee = estimations[2]; // 0.05%
+
+        assert.equal(expectedNetPrice.toString(), parseEther("1.194").toString());
+        assert.equal(expectedTradingFee.toString(), parseEther("0.0054").toString());
+        assert.equal(expectedCreatorFee.toString(), parseEther("0.0006").toString());
+
+        const result = await collectibleMarket.buyTokenUsingBNB(mockNFT2.address, "2", {
+          value: marketPrice,
+          from: buyer2,
+        });
+
+        expectEvent(result, "Trade", {
+          collection: mockNFT2.address,
+          tokenId: "2",
+          seller: seller2,
+          buyer: buyer2,
+          askPrice: marketPrice,
+          netPrice: expectedNetPrice,
+          withBNB: true,
+        });
+
+        expectEvent.inTransaction(result.receipt.transactionHash, wrappedBNB, "Transfer", {
+          src: collectibleMarket.address,
+          dst: seller2,
+          wad: expectedNetPrice,
+        });
+
+        assert.equal(String(await collectibleMarket.pendingRevenue(treasury)), expectedTradingFee);
+        assert.equal(String(await collectibleMarket.pendingRevenue(creator1)), expectedCreatorFee);
+      });
+
+      it("Creator and treasury claim pending revenue", async () => {
+        let result = await collectibleMarket.claimPendingRevenue({ from: treasury });
+
+        expectEvent.inTransaction(result.receipt.transactionHash, wrappedBNB, "Transfer", {
+          src: collectibleMarket.address,
+          dst: treasury,
+          wad: parseEther("0.0054").toString(),
+        });
+
+        result = await collectibleMarket.claimPendingRevenue({ from: creator1 });
+
+        expectEvent.inTransaction(result.receipt.transactionHash, wrappedBNB, "Transfer", {
+          src: collectibleMarket.address,
+          dst: creator1,
+          wad: parseEther("0.0006").toString(),
+        });
+
+        assert.equal(String(await collectibleMarket.pendingRevenue(treasury)), "0");
+        assert.equal(String(await collectibleMarket.pendingRevenue(creator1)), "0");
+      });
+    });
+
+    describe("COLLECTIBLE MARKET #2 - ALTERNATIVE BEHAVIOR", async () => {
+      it("Cannot buy a token not for sale", async () => {
+        await expectRevert(
+          collectibleMarket.buyTokenUsingBNB(mockNFT1.address, "10", {
+            from: buyer1,
+            value: parseEther("1").toString(),
+          }),
+          "Buy: Not for sale"
+        );
+      });
+
+      it("Cannot list a tokenId if caller is not the owner", async () => {
+        // Seller1 cannot create an order for a token it doesn't own
+        await expectRevert(
+          collectibleMarket.createAskOrder(mockNFT2.address, "5", parseEther("1.1"), 0, {
+            from: seller1,
+          }),
+          "ERC721: transfer of token that is not own"
+        );
+      });
+
+      it("Cannot buy own offer", async () => {
+        // Seller1 puts a ask order for tokenId = 0 at 1BNB
+        await collectibleMarket.createAskOrder(mockNFT2.address, "0", parseEther("1"), 0, {
+          from: seller1,
+        });
+
+        // Seller1 cannot purchase its own offer for 1 WBNB
+        await expectRevert(
+          collectibleMarket.buyTokenUsingBNB(mockNFT2.address, "0", {
+            value: parseEther("1").toString(),
+            from: seller1,
+          }),
+          "Buy: Buyer cannot be seller"
+        );
+
+        // Seller1 cannot purchase its own offer for 1 WBNB
+        await expectRevert(
+          collectibleMarket.buyTokenUsingWBNB(mockNFT2.address, "0", parseEther("1"), {
+            from: seller1,
+          }),
+          "Buy: Buyer cannot be seller"
+        );
+      });
+
+      it("Price front-running protections work as expected", async () => {
+        // Seller1 cannot purchase its own offer for 1.0000000001 BNB
+        await expectRevert(
+          collectibleMarket.buyTokenUsingBNB(mockNFT2.address, "0", {
+            value: parseEther("1.0000000001").toString(),
+            from: seller1,
+          }),
+          "Buy: Incorrect price"
+        );
+
+        // Seller1 cannot purchase its own offer for 1.0000000001 WBNB
+        await expectRevert(
+          collectibleMarket.buyTokenUsingWBNB(mockNFT2.address, "0", parseEther("1.0000000001"), {
+            from: seller1,
+          }),
+          "Buy: Incorrect price"
+        );
+
+        // Seller1 cannot purchase its own offer for 0.9999999999 BNB
+        await expectRevert(
+          collectibleMarket.buyTokenUsingBNB(mockNFT2.address, "0", {
+            value: parseEther("0.9999999999").toString(),
+            from: seller1,
+          }),
+          "Buy: Incorrect price"
+        );
+
+        // Seller1 cannot purchase its own offer for 0.9999999999 WBNB
+        await expectRevert(
+          collectibleMarket.buyTokenUsingWBNB(mockNFT2.address, "0", parseEther("0.9999999999"), {
+            from: seller1,
+          }),
+          "Buy: Incorrect price"
+        );
+      });
+
+      it("Cannot list assets if the collection is not approved", async () => {
+        // Seller1 cannot create an order
+        await expectRevert(
+          collectibleMarket.createAskOrder(mockNFT3.address, "1", parseEther("1.1"), 0, {
+            from: seller1,
+          }),
+          "Collection: Not for listing"
+        );
+      });
+
+      it("Cannot list, trade, nor modify price once collection is discontinued", async () => {
+        const result = await collectibleMarket.closeCollectionForTradingAndListing(mockNFT2.address, { from: admin });
+
+        expectEvent(result, "CollectionClose", { collection: mockNFT2.address });
+
+        // Seller1 cannot create an order
+        await expectRevert(
+          collectibleMarket.createAskOrder(mockNFT2.address, "1", parseEther("1.1"), 0, {
+            from: seller1,
+          }),
+          "Collection: Not for listing"
+        );
+
+        // Seller1 cannot change price of an order
+        await expectRevert(
+          collectibleMarket.modifyAskOrder(mockNFT2.address, "0", parseEther("1.1"), 0, {
+            from: seller1,
+          }),
+          "Collection: Not for listing"
+        );
+
+        // Buyer1 cannot change purchase the tokenId=0 for 1 BNB
+        await expectRevert(
+          collectibleMarket.buyTokenUsingBNB(mockNFT2.address, "0", {
+            value: parseEther("1").toString(),
+            from: buyer1,
+          }),
+          "Collection: Not for trading"
+        );
+
+        // Buyer1 cannot change purchase the tokenId=0 for 1 BNB
+        await expectRevert(
+          collectibleMarket.buyTokenUsingWBNB(mockNFT2.address, "0", parseEther("1"), {
+            from: buyer1,
+          }),
+          "Collection: Not for trading"
+        );
+      });
+    });
+
+    describe("COLLECTIBLE MARKET #3 - TOKEN RESTRICTIONS/PANCAKEBUNNIES", async () => {
+      it("Add collection with restrictions", async () => {
+        const result = await collectibleMarket.addCollection(
+          pancakeBunnies.address,
+          constants.ZERO_ADDRESS,
+          pancakeBunniesChecker.address,
+          "100", // 1%
+          "0",
+          { from: admin }
+        );
+
+        expectEvent(result, "CollectionNew", {
+          collection: pancakeBunnies.address,
+          creator: constants.ZERO_ADDRESS,
+          whitelistChecker: pancakeBunniesChecker.address,
+          tradingFee: "100",
+          creatorFee: "0",
+        });
+
+        assert.equal(await pancakeBunniesChecker.canList("1"), true);
+        assert.equal(await pancakeBunniesChecker.canList("2"), true);
+        assert.equal(await pancakeBunniesChecker.canList("3"), true);
+        assert.equal(await pancakeBunniesChecker.canList("4"), true);
+        assert.equal(await pancakeBunniesChecker.canList("211"), true);
+
+        const tokenListingStatuses = await collectibleMarket.canTokensBeListed(pancakeBunnies.address, [
+          "0",
+          "1",
+          "2",
+          "3",
+          "4",
+          "5",
+        ]);
+
+        const boolArray = Array.from({ length: 6 }, (i) => (i = true));
+
+        assert.sameOrderedMembers(tokenListingStatuses, boolArray);
+      });
+
+      it("Owner mint bunnyId 1-5 for seller1 and owner adds restrictions for bunnyId 3/4", async () => {
+        let i = 0;
+
+        while (i < 5) {
+          await pancakeBunnies.mint(seller1, "ipfs://" + i.toString(), i, { from: owner });
+          i++;
+        }
+
+        const result = await pancakeBunniesChecker.addRestrictionForBunnies([new BN("3"), new BN("4")]);
+        expectEvent(result, "NewRestriction");
+
+        assert.equal(await pancakeBunniesChecker.isBunnyIdRestricted("3"), true);
+        assert.equal(await pancakeBunniesChecker.isBunnyIdRestricted("4"), true);
+
+        // For convenience, tokenId = 0 --> bunnyId = 0, tokenId = 1 --> bunnyId = 1
+        assert.equal(await pancakeBunniesChecker.canList("3"), false);
+        assert.equal(await pancakeBunniesChecker.canList("4"), false);
+
+        const tokenListingStatuses = await collectibleMarket.canTokensBeListed(pancakeBunnies.address, ["3", "4"]);
+        const boolArray = Array.from({ length: 2 }, (i) => (i = false));
+        assert.sameOrderedMembers(tokenListingStatuses, boolArray);
+      });
+
+      it("Seller 1 can sell tokenIds 0-2 (bunnyIds 0-2)", async () => {
+        await pancakeBunnies.setApprovalForAll(collectibleMarket.address, true, { from: seller1 });
+
+        let result = await collectibleMarket.createAskOrder(pancakeBunnies.address, "0", parseEther("1"), 0, {
+          from: seller1,
+        });
+
+        expectEvent(result, "AskNew", {
+          collection: pancakeBunnies.address,
+          seller: seller1,
+          tokenId: "0",
+          askPrice: parseEther("1").toString(),
+          currency: "0",
+        });
+
+        result = await collectibleMarket.createAskOrder(pancakeBunnies.address, "1", parseEther("1"), 0, {
+          from: seller1,
+        });
+
+        expectEvent(result, "AskNew", {
+          collection: pancakeBunnies.address,
+          seller: seller1,
+          tokenId: "1",
+          askPrice: parseEther("1").toString(),
+          currency: "0",
+        });
+
+        result = await collectibleMarket.createAskOrder(pancakeBunnies.address, "2", parseEther("1"), 0, {
+          from: seller1,
+        });
+
+        expectEvent(result, "AskNew", {
+          collection: pancakeBunnies.address,
+          seller: seller1,
+          tokenId: "2",
+          askPrice: parseEther("1").toString(),
+          currency: "0",
+        });
+      });
+
+      it("Seller 1 cannot sell tokenIds 3-4 (bunnyIds 3-4)", async () => {
+        await expectRevert(
+          collectibleMarket.createAskOrder(pancakeBunnies.address, "3", parseEther("1"), 0, {
+            from: seller1,
+          }),
+          "Order: tokenId not eligible"
+        );
+
+        await expectRevert(
+          collectibleMarket.createAskOrder(pancakeBunnies.address, "4", parseEther("1"), 0, {
+            from: seller1,
+          }),
+          "Order: tokenId not eligible"
+        );
+      });
+
+      it("Owner removes restrictions for bunnyId=4", async () => {
+        let result = await pancakeBunniesChecker.removeRestrictionForBunnies([new BN("4")]);
+        expectEvent(result, "RemoveRestriction");
+
+        assert.equal(await pancakeBunniesChecker.isBunnyIdRestricted("3"), true);
+        assert.equal(await pancakeBunniesChecker.isBunnyIdRestricted("4"), false);
+        assert.equal(await pancakeBunniesChecker.canList("3"), false);
+        assert.equal(await pancakeBunniesChecker.canList("4"), true);
+
+        const tokenListingStatuses = await collectibleMarket.canTokensBeListed(pancakeBunnies.address, ["3", "4"]);
+        assert.equal(tokenListingStatuses[0], false);
+        assert.equal(tokenListingStatuses[1], true);
+
+        result = await collectibleMarket.createAskOrder(pancakeBunnies.address, "4", parseEther("1"), 0, {
+          from: seller1,
+        });
+
+        expectEvent(result, "AskNew", {
+          collection: pancakeBunnies.address,
+          seller: seller1,
+          tokenId: "4",
+          askPrice: parseEther("1").toString(),
+          currency: "0",
+        });
+      });
+
+      it("Revert statements work as expected", async () => {
+        await expectRevert(
+          pancakeBunniesChecker.removeRestrictionForBunnies([new BN("3"), new BN("4")], { from: owner }),
+          "Operations: Not restricted"
+        );
+
+        await expectRevert(
+          pancakeBunniesChecker.addRestrictionForBunnies([new BN("3"), new BN("4")], { from: owner }),
+          "Operations: Already restricted"
+        );
+      });
+    });
+
+    describe("COLLECTIBLE MARKET #4 - ADMIN/OWNER/SPECIAL BEHAVIOR", async () => {
+      it("Can recover tokens sent by accident", async () => {
+        // Random ERC20
+        await mockERC20.transfer(collectibleMarket.address, parseEther("1"), { from: owner });
+        let result = await collectibleMarket.recoverFungibleTokens(mockERC20.address, { from: owner });
+        expectEvent(result, "TokenRecovery", { token: mockERC20.address, amount: parseEther("1").toString() });
+
+        // MockNFT1 tokenId not listed
+        await mockNFT1.transferFrom(buyer1, collectibleMarket.address, "1", { from: buyer1 });
+        result = await collectibleMarket.recoverNonFungibleToken(mockNFT1.address, "1", { from: owner });
+        expectEvent(result, "NonFungibleTokenRecovery", { token: mockNFT1.address, tokenId: "1" });
+
+        // MockNFT3 (collection not approved)
+        await mockNFT3.transferFrom(seller2, collectibleMarket.address, "3", { from: seller2 });
+        result = await collectibleMarket.recoverNonFungibleToken(mockNFT3.address, "3", { from: owner });
+        expectEvent(result, "NonFungibleTokenRecovery", { token: mockNFT3.address, tokenId: "3" });
+      });
+
+      it("Cannot recover if nothing to, WBNB or NFTs that are listed", async () => {
+        // Cannot recover if balanceOf is 0
+        await expectRevert(
+          collectibleMarket.recoverFungibleTokens(mockERC20.address, { from: owner }),
+          "Operations: No token to recover"
+        );
+
+        // Cannot recover WBNB
+        await wrappedBNB.transfer(collectibleMarket.address, parseEther("1"), { from: buyer3 });
+        await expectRevert(
+          collectibleMarket.recoverFungibleTokens(wrappedBNB.address, { from: owner }),
+          "Operations: Cannot recover WBNB"
+        );
+
+        // Cannot recover token that is still in the orderbook
+        await expectRevert(
+          collectibleMarket.recoverNonFungibleToken(mockNFT2.address, "0", { from: owner }),
+          "Operations: NFT not recoverable"
+        );
+      });
+
+      it("Cannot add a collection if already listed or wrong creator attributes", async () => {
+        // Collection already listed
+        await expectRevert(
+          collectibleMarket.addCollection(
+            mockNFT1.address,
+            creator1,
+            constants.ZERO_ADDRESS,
+            "45", // 0.45%
+            "5", // 0.05%
+            { from: admin }
+          ),
+          "Operations: Collection already listed"
+        );
+
+        // Creator address is set but fee is 0
+        await expectRevert(
+          collectibleMarket.addCollection(
+            mockNFT3.address,
+            creator1,
+            constants.ZERO_ADDRESS,
+            "45",
+            "0", // creatorFee
+            { from: admin }
+          ),
+          "Operations: Creator parameters incorrect"
+        );
+
+        // Fee is set for creator but address isn't
+        await expectRevert(
+          collectibleMarket.addCollection(
+            mockNFT3.address,
+            constants.ZERO_ADDRESS, // creator address
+            constants.ZERO_ADDRESS,
+            "45",
+            "1",
+            {
+              from: admin,
+            }
+          ),
+          "Operations: Creator parameters incorrect"
+        );
+      });
+
+      it("Cannot add a collection if not ERC721", async () => {
+        await expectRevert(
+          collectibleMarket.addCollection(
+            mockERC20.address, // MockERC20 instead of MockNFT3
+            creator1,
+            constants.ZERO_ADDRESS,
+            "45", // 0.45%
+            "5", // 0.05%
+            { from: admin }
+          ),
+          "function selector was not recognized and there's no fallback function"
+        );
+      });
+
+      it("Cannot add/modify a collection with fees too high", async () => {
+        const maxFee = await collectibleMarket.TOTAL_MAX_FEE();
+
+        await expectRevert(
+          collectibleMarket.addCollection(
+            mockNFT3.address,
+            creator1,
+            constants.ZERO_ADDRESS,
+            maxFee,
+            "1", // 0.01
+            { from: admin }
+          ),
+          "Operations: Sum of fee must inferior to TOTAL_MAX_FEE"
+        );
+
+        await expectRevert(
+          collectibleMarket.modifyCollection(
+            mockNFT1.address,
+            creator1,
+            constants.ZERO_ADDRESS,
+            maxFee,
+            "1", // 0.01
+            { from: admin }
+          ),
+          "Operations: Sum of fee must inferior to TOTAL_MAX_FEE"
+        );
+      });
+
+      it("Cannot modify or remove a collection if not listed", async () => {
+        await expectRevert(
+          collectibleMarket.modifyCollection(
+            mockNFT3.address,
+            creator1,
+            constants.ZERO_ADDRESS,
+            "45", // 0.45%
+            "5", // 0.05%
+            { from: admin }
+          ),
+          "Operations: Collection not listed"
+        );
+
+        await expectRevert(
+          collectibleMarket.closeCollectionForTradingAndListing(mockNFT3.address, { from: admin }),
+          "Operations: Collection not listed"
+        );
+      });
+
+      it("Cannot modify a collection with wrong creator parameters", async () => {
+        // Creator address is set but fee is 0
+        await expectRevert(
+          collectibleMarket.modifyCollection(
+            mockNFT1.address,
+            creator1,
+            constants.ZERO_ADDRESS,
+            "45",
+            "0", // creatorFee
+            { from: admin }
+          ),
+          "Operations: Creator parameters incorrect"
+        );
+
+        // Fee is set for creator but address isn't
+        await expectRevert(
+          collectibleMarket.modifyCollection(
+            mockNFT1.address,
+            constants.ZERO_ADDRESS, // creator address
+            constants.ZERO_ADDRESS,
+            "45",
+            "1",
+            {
+              from: admin,
+            }
+          ),
+          "Operations: Creator parameters incorrect"
+        );
+      });
+
+      it("Cannot change min/max prices if maxPrice >= minPrice", async () => {
+        await expectRevert(
+          collectibleMarket.updateMinimumAndMaximumPrices(minimumAskPrice, minimumAskPrice, { from: admin }),
+          "Operations: _minimumAskPrice < _maximumAskPrice"
+        );
+      });
+
+      it("Only admin can call admin functions", async () => {
+        for (let user of [buyer1, seller1, owner]) {
+          await expectRevert(
+            collectibleMarket.addCollection(
+              mockNFT2.address,
+              creator1,
+              constants.ZERO_ADDRESS,
+              "45", // 0.45%
+              "5", // 0.05%
+              { from: user }
+            ),
+            "Management: Not admin"
+          );
+
+          await expectRevert(
+            collectibleMarket.modifyCollection(
+              mockNFT2.address,
+              creator1,
+              constants.ZERO_ADDRESS,
+              "45", // 0.45%
+              "5", // 0.05%
+              { from: user }
+            ),
+            "Management: Not admin"
+          );
+
+          await expectRevert(
+            collectibleMarket.updateMinimumAndMaximumPrices("0", "10", { from: user }),
+            "Management: Not admin"
+          );
+
+          await expectRevert(
+            collectibleMarket.closeCollectionForTradingAndListing(mockNFT1.address, { from: user }),
+            "Management: Not admin"
+          );
+        }
+      });
+
+      it("Only owner can call owner functions", async () => {
+        for (let user of [buyer1, seller1, admin]) {
+          await expectRevert(
+            collectibleMarket.recoverFungibleTokens(mockERC20.address, { from: user }),
+            "Ownable: caller is not the owner"
+          );
+
+          await expectRevert(
+            collectibleMarket.recoverNonFungibleToken(mockNFT3.address, "1", { from: user }),
+            "Ownable: caller is not the owner"
+          );
+
+          await expectRevert(
+            collectibleMarket.setAdminAndTreasuryAddresses(seller1, seller2, { from: user }),
+            "Ownable: caller is not the owner"
+          );
+        }
+      });
+
+      it("Estimations for price returns (0,0,0) if collection is not listed", async () => {
+        const result = await collectibleMarket.calculatePriceAndFeesForCollection(mockNFT3.address, parseEther("10"));
+        assert.equal(result[0], "0");
+        assert.equal(result[1], "0");
+        assert.equal(result[2], "0");
+      });
+
+      it("Owner can change admin/treasury but cannot if one of them is equal to 0x address", async () => {
+        const result = await collectibleMarket.setAdminAndTreasuryAddresses(admin, treasury, {
+          from: owner,
+        });
+
+        expectEvent(result, "NewAdminAndTreasuryAddresses", { admin: admin, treasury: treasury });
+
+        await expectRevert(
+          collectibleMarket.setAdminAndTreasuryAddresses(admin, constants.ZERO_ADDRESS, { from: owner }),
+          "Operations: Treasury address cannot be zero"
+        );
+
+        await expectRevert(
+          collectibleMarket.setAdminAndTreasuryAddresses(constants.ZERO_ADDRESS, treasury, { from: owner }),
+          "Operations: Admin address cannot be zero"
+        );
+      });
+
+      it("Cannot deploy if wrong admin address/treasury and maxPrice <= minPrice", async () => {
+        await expectRevert(
+          ERC721NFTMarketV2.new(
+            constants.ZERO_ADDRESS,
+            treasury,
+            wrappedBNB.address,
+            cake.address,
+            minimumAskPrice,
+            maximumAskPrice,
+            minimumAskCakePrice,
+            maximumAskCakePrice,
+            { from: owner }
+          ),
+          "Operations: Admin address cannot be zero"
+        );
+
+        await expectRevert(
+          ERC721NFTMarketV2.new(
+            admin,
+            constants.ZERO_ADDRESS,
+            wrappedBNB.address,
+            cake.address,
+            minimumAskPrice,
+            maximumAskPrice,
+            minimumAskCakePrice,
+            maximumAskCakePrice,
+            {
+              from: owner,
+            }
+          ),
+          "Operations: Treasury address cannot be zero"
+        );
+
+        await expectRevert(
+          ERC721NFTMarketV2.new(
+            admin,
+            treasury,
+            constants.ZERO_ADDRESS,
+            cake.address,
+            minimumAskPrice,
+            maximumAskPrice,
+            minimumAskCakePrice,
+            maximumAskCakePrice,
+            {
+              from: owner,
+            }
+          ),
+          "Operations: WBNB address cannot be zero"
+        );
+
+        await expectRevert(
+          ERC721NFTMarketV2.new(
+            admin,
+            treasury,
+            wrappedBNB.address,
+            constants.ZERO_ADDRESS,
+            minimumAskPrice,
+            maximumAskPrice,
+            minimumAskCakePrice,
+            maximumAskCakePrice,
+            {
+              from: owner,
+            }
+          ),
+          "Operations: Cake address cannot be zero"
+        );
+
+        await expectRevert(
+          ERC721NFTMarketV2.new(
+            admin,
+            treasury,
+            wrappedBNB.address,
+            cake.address,
+            minimumAskPrice,
+            maximumAskPrice,
+            minimumAskCakePrice,
+            minimumAskCakePrice,
+            {
+              from: owner,
+            }
+          ),
+          "Operations: _minimumAskCakePrice < _maximumAskCakePrice"
+        );
+
+        await expectRevert(
+          ERC721NFTMarketV2.new(
+            admin,
+            treasury,
+            wrappedBNB.address,
+            cake.address,
+            minimumAskPrice,
+            minimumAskPrice,
+            minimumAskCakePrice,
+            maximumAskCakePrice,
+            {
+              from: owner,
+            }
+          ),
+          "Operations: _minimumAskPrice < _maximumAskPrice"
+        );
+      });
+    });
+    describe("COLLECTIBLE MARKET #5 - VIEW FUNCTIONS", async () => {
+      it("Add fourth collection whose tokens are minted/listed by seller3", async () => {
+        const result = await collectibleMarket.addCollection(
+          mockNFT4.address,
+          constants.ZERO_ADDRESS,
+          constants.ZERO_ADDRESS,
+          "100", // 1%
+          "0",
+          { from: admin }
+        );
+
+        expectEvent(result, "CollectionNew", {
+          collection: mockNFT4.address,
+          creator: constants.ZERO_ADDRESS,
+          whitelistChecker: constants.ZERO_ADDRESS,
+          tradingFee: "100",
+          creatorFee: "0",
+        });
+
+        // Mint 30 NFTs and approve
+        let i = 0;
+
+        while (i < 30) {
+          await mockNFT4.mint("ipfs://token" + i + " .json", { from: seller3 });
+          // tokenId = 0 --> 1 BNB, tokenId = 5 --> 1.5 BNB, tokenId = 30 --> 4 BNB, etc.
+          const priceToList = parseEther(String(1 + i / 10));
+          // Set approvals for all future NFTs minted
+          await mockNFT4.setApprovalForAll(collectibleMarket.address, true, { from: seller3 });
+
+          const result = await collectibleMarket.createAskOrder(mockNFT4.address, i, priceToList, 0, {
+            from: seller3,
+          });
+
+          expectEvent(result, "AskNew", {
+            collection: mockNFT4.address,
+            seller: seller3,
+            tokenId: i.toString(),
+            askPrice: priceToList.toString(),
+            currency: "0",
+          });
+
+          expectEvent.inTransaction(result.receipt.transactionHash, mockNFT4, "Transfer", {
+            from: seller3,
+            to: collectibleMarket.address,
+            tokenId: i.toString(),
+          });
+
+          // Increment i
+          i++;
+        }
+      });
+
+      it("viewCollections", async () => {
+        let collections = await collectibleMarket.viewCollections("0", "1");
+        assert.equal(String(collections[2]), "1"); // 3 collections
+        collections = await collectibleMarket.viewCollections("1", "1");
+        assert.equal(String(collections[2]), "2"); // 3 collections
+        collections = await collectibleMarket.viewCollections("2", "1");
+        assert.equal(String(collections[2]), "3"); // 3 collections
+        collections = await collectibleMarket.viewCollections("3", "1");
+        assert.equal(String(collections[2]), "3"); // 3 collections
+      });
+
+      it("viewAsksByCollectionAndSeller", async () => {
+        let collections = await collectibleMarket.viewAsksByCollectionAndSeller(mockNFT4.address, seller3, "0", "10");
+        assert.equal(String(collections[2]), "10"); // 30 tokens
+        collections = await collectibleMarket.viewAsksByCollectionAndSeller(mockNFT4.address, seller3, "10", "15");
+        assert.equal(String(collections[2]), "25"); // 150 tokens
+        collections = await collectibleMarket.viewAsksByCollectionAndSeller(mockNFT4.address, seller3, "25", "70");
+        assert.equal(String(collections[2]), "30"); // 150 tokens
+      });
+
+      it("viewAsksByCollectionAndTokenIds", async () => {
+        let collections = await collectibleMarket.viewAsksByCollectionAndTokenIds(mockNFT4.address, [
+          new BN("0"),
+          new BN("1"),
+          new BN("2"),
+          new BN("100023"),
+        ]);
+
+        assert.equal(collections[0][0], true);
+        assert.equal(collections[0][1], true);
+        assert.equal(collections[0][2], true);
+        assert.equal(collections[0][3], false);
+
+        assert.equal(collections[1][0][0], seller3);
+        assert.equal(collections[1][1][0], seller3);
+        assert.equal(collections[1][2][0], seller3);
+        assert.equal(collections[1][3][0], constants.ZERO_ADDRESS);
+
+        assert.equal(String(collections[1][0][1]), parseEther("1").toString());
+        assert.equal(String(collections[1][1][1]), parseEther("1.1").toString());
+        assert.equal(String(collections[1][2][1]), parseEther("1.2").toString());
+        assert.equal(String(collections[1][3][1]), parseEther("0").toString());
+      });
+
+      it("viewAsksByCollection", async () => {
+        let collections = await collectibleMarket.viewAsksByCollection(mockNFT4.address, "0", "10");
+
+        assert.equal(String(collections[2]), "10"); // 150 tokens
+        collections = await collectibleMarket.viewAsksByCollection(mockNFT4.address, "10", "15");
+        assert.equal(String(collections[2]), "25"); // 150 tokens
+        collections = await collectibleMarket.viewAsksByCollection(mockNFT4.address, "25", "70");
+        assert.equal(String(collections[2]), "30"); // 150 tokens
+      });
+    });
+
+    describe("COLLECTIBLE MARKET #6 - Cake Payments", async () => {
+      it("Admin adds a new collection (Mock NFT #5)", async () => {
+        const result = await collectibleMarket.addCollection(
+          mockNFT5.address,
+          constants.ZERO_ADDRESS,
+          constants.ZERO_ADDRESS,
+          "100",
+          "0",
+          { from: admin }
+        );
+
+        expectEvent(result, "CollectionNew", {
+          collection: mockNFT5.address,
+          creator: constants.ZERO_ADDRESS,
+          whitelistChecker: constants.ZERO_ADDRESS,
+          tradingFee: "100",
+          creatorFee: "0",
+        });
+      });
+      it("Seller 1 lists a NFT with Cake", async () => {
+        const result = await collectibleMarket.createAskOrder(mockNFT5.address, "1", 5000, 1, {
+          from: seller1,
+        });
+
+        expectEvent(result, "AskNew", {
+          collection: mockNFT5.address,
+          seller: seller1,
+          tokenId: "1",
+          askPrice: (5000).toString(),
+          currency: "1",
+        });
+
+        expectEvent.inTransaction(result.receipt.transactionHash, mockNFT5, "Transfer", {
+          from: seller1,
+          to: collectibleMarket.address,
+          tokenId: "1",
+        });
+
+        const tokensForSale = await collectibleMarket.viewAsksByCollection(mockNFT5.address, "0", "500");
+        assert.equal(tokensForSale[0][0], "1"); // TokenId = 1
+        assert.equal(tokensForSale[1][0][0], seller1); // Address = seller1
+        assert.equal(String(tokensForSale[1][0][1]), (5000).toString()); // Price = 1 BNB
+        assert.equal(String(tokensForSale[2]), "1"); // 1 token listed in the collection
+      });
+      it("Seller2 lists a NFT and modifies the order price", async () => {
+        const firstPrice = 6000;
+        const secondPrice = 9000;
+        let result = await collectibleMarket.createAskOrder(mockNFT5.address, "2", firstPrice, 1, {
+          from: seller2,
+        });
+
+        expectEvent(result, "AskNew", {
+          collection: mockNFT5.address,
+          seller: seller2,
+          tokenId: "2",
+          askPrice: firstPrice.toString(),
+          currency: "1",
+        });
+
+        expectEvent.inTransaction(result.receipt.transactionHash, mockNFT5, "Transfer", {
+          from: seller2,
+          to: collectibleMarket.address,
+          tokenId: "2",
+        });
+
+        let tokensForSale = await collectibleMarket.viewAsksByCollection(mockNFT5.address, "0", "500");
+        assert.equal(tokensForSale[0][1], "2"); // TokenId = 2
+        assert.equal(tokensForSale[1][1][0], seller2); // Address = seller2
+        assert.equal(String(tokensForSale[1][1][1]), firstPrice.toString()); // Price = 6000 cake
+        assert.equal(String(tokensForSale[2]), "2"); // 2 tokens listed in the collection
+
+        result = await collectibleMarket.modifyAskOrder(mockNFT5.address, "2", secondPrice, 1, {
+          from: seller2,
+        });
+
+        expectEvent(result, "AskUpdate", {
+          collection: mockNFT5.address,
+          seller: seller2,
+          tokenId: "2",
+          askPrice: secondPrice.toString(),
+          currency: "1",
+        });
+
+        tokensForSale = await collectibleMarket.viewAsksByCollection(mockNFT5.address, "0", "500");
+        assert.equal(String(tokensForSale[1][1][1]), secondPrice.toString()); // Price updated to 9000 cake
+      });
+
+      it("Buyer1 matches order from seller1 with Cake", async () => {
+        const marketPrice = (5000).toString();
+
+        const estimations = await collectibleMarket.calculatePriceAndFeesForCollection(mockNFT5.address, marketPrice);
+        const expectedNetPrice = estimations[0];
+        const expectedTradingFee = estimations[1];
+        const expectedCreatorFee = estimations[2];
+
+        assert.equal(expectedNetPrice.toString(), (4950).toString());
+        assert.equal(expectedTradingFee.toString(), (50).toString());
+        assert.equal(expectedCreatorFee.toString(), (0).toString());
+
+        await cake.approve(collectibleMarket.address, marketPrice, { from: buyer1 });
+
+        const result = await collectibleMarket.buyTokenUsingCake(mockNFT5.address, "1", marketPrice, {
+          from: buyer1,
+        });
+
+        expectEvent(result, "Trade", {
+          collection: mockNFT5.address,
+          tokenId: "1",
+          seller: seller1,
+          buyer: buyer1,
+          askPrice: marketPrice,
+          netPrice: expectedNetPrice,
+          withBNB: false,
+        });
+
+        assert.equal((await cake.balanceOf(buyer1)).toString(), (15000).toString());
+        assert.equal((await cake.balanceOf(collectibleMarket.address)).toString(), (50).toString());
+        assert.equal((await cake.balanceOf(treasury)).toString(), (0).toString());
+        assert.equal((await cake.balanceOf(seller1)).toString(), (4950).toString());
+        assert.equal((await collectibleMarket.cakePendingRevenue(treasury)).toString(), (50).toString());
+      });
+
+      it("Treasury claims its pending cake revenue", async () => {
+        const result = await collectibleMarket.claimPendingRevenue({ from: treasury });
+
+        assert.equal((await cake.balanceOf(treasury)).toString(), (50).toString());
+        assert.equal((await collectibleMarket.cakePendingRevenue(treasury)).toString(), (0).toString());
+
+        await expectRevert(collectibleMarket.claimPendingRevenue({ from: treasury }), "Claim: Nothing to claim");
+      });
+    });
+  }
+);


### PR DESCRIPTION
It's my first commit to completing the Pancake swap bounty at the revelation hackathon.

I have created a version 2 marketplace based on the v1 and its tests. Added the Cake as a payment method.

In the constructor, the deployer specifies the Cake contract address + cake min price + cake max price.

Added an enum which is called currency which contains two currencies: BNB and Cake

Modified Ask struct to also have a currency property, also updated the events belonging to it.

Added another public function called buyTokenUsingCake which can be used for asks that are based on Cake.

Added a cakePendingRevenue which will be used for pending revenues based on the cake. 

Updated _buyToken and claimPendingRevenue to act as expected.

Modified old tests to work with the current version, and also added new tests for new features.

==========

This is a work in progress. I will add offers and erc1155 in the coming days.

I'm also creating a new indexer here: https://github.com/Ajand/evm-nft-indexer
Since your old indexer was developed using java and I'm not a good java developer, the old one needed HUGE changes to be useable for the new marketplace, since you need dynamic collections and the ability to index erc1155, I'm creating a new one from scratch.